### PR TITLE
Admin girişi rastgele işçi olarak gösteriliyor

### DIFF
--- a/Controllers/EmployeeController.cs
+++ b/Controllers/EmployeeController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.JSInterop.Infrastructure; // << EKLENDİ
 
 namespace kebapbackend.Controllers
 {
@@ -15,8 +14,7 @@ namespace kebapbackend.Controllers
     public class EmployeeController : ControllerBase
     {
         private readonly AppDbContext _context;
-
-        private readonly PasswordHasher<User> _passwordHasher = new PasswordHasher<User>(); // << EKLENDİ
+        private readonly PasswordHasher<User> _passwordHasher = new PasswordHasher<User>();
 
         public EmployeeController(AppDbContext context)
         {
@@ -53,7 +51,7 @@ namespace kebapbackend.Controllers
             {
                 return Forbid("Sadece admin kullanıcılar çalışan ekleyebilir.");
             }
-        {
+
             try
             {
                 Console.WriteLine("🔥 POST METODU ÇALIŞTI!");
@@ -79,25 +77,25 @@ namespace kebapbackend.Controllers
 
                 // Otomatik hesap oluştur
                 var tempPassword = GenerateTempPassword();
-                var username = await GenerateUsername(employee.Name);
+                var generatedUsername = await GenerateUsername(employee.Name);
 
                 Console.WriteLine("🚀 ŞİFRE OLUŞTURULDU!");
                 Console.WriteLine($"=== YENİ ÇALIŞAN HESABI ===");
                 Console.WriteLine($"İsim: {employee.Name}");
-                Console.WriteLine($"Username: {username}");
+                Console.WriteLine($"Username: {generatedUsername}");
                 Console.WriteLine($"Geçici Şifre: {tempPassword}");
                 Console.WriteLine($"Tarih: {DateTime.Now}");
                 Console.WriteLine($"==========================");
+
                 var newUser = new User
                 {
-                    Username = username,
-                    Email = $"{username}@gmail.com",
+                    Username = generatedUsername,
+                    Email = $"{generatedUsername}@gmail.com",
                     Name = employee.Name,
                     Position = employee.Position,
                     MustChangePassword = true,
                     TempPassword = tempPassword,
                     CreatedAt = DateTime.UtcNow,
-
                     EmployeeId = employee.Id
                 };
 
@@ -113,7 +111,7 @@ namespace kebapbackend.Controllers
                     Employee = employee,
                     Account = new
                     {
-                        Username = username,
+                        Username = generatedUsername,
                         TempPassword = tempPassword,
                         Message = "Hesap otomatik oluşturuldu. İşçi ilk girişte şifresini değiştirmek zorunda."
                     }

--- a/Controllers/EmployeeController.cs
+++ b/Controllers/EmployeeController.cs
@@ -1,4 +1,4 @@
-﻿using kebapbackend.Data;
+using kebapbackend.Data;
 using kebapbackend.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -46,6 +46,14 @@ namespace kebapbackend.Controllers
         [HttpPost]
         public async Task<ActionResult<object>> Post(Employee employee)
         {
+            // Admin kontrolü
+            var username = User.Identity?.Name;
+            var user = await _context.Users.FirstOrDefaultAsync(u => u.Username == username);
+            if (user == null || user.Position != "admin")
+            {
+                return Forbid("Sadece admin kullanıcılar çalışan ekleyebilir.");
+            }
+        {
             try
             {
                 Console.WriteLine("🔥 POST METODU ÇALIŞTI!");
@@ -55,6 +63,13 @@ namespace kebapbackend.Controllers
                 {
                     Console.WriteLine("❌ Validation hatası: Name veya Position boş");
                     return BadRequest("Name and Position are required.");
+                }
+
+                // Position kontrolü - admin position'ı kullanılamaz
+                if (employee.Position.ToLower() == "admin")
+                {
+                    Console.WriteLine("❌ Validation hatası: 'admin' position'ı kullanılamaz");
+                    return BadRequest("'admin' position'ı kullanılamaz. Lütfen farklı bir position seçin.");
                 }
 
                 // Employee'ı kaydet


### PR DESCRIPTION
Distinguish admin user from employees by setting a unique 'admin' position and adding related access controls and info endpoints.

The original setup assigned "manager" position to the admin, which could also be used by regular employees. This led to confusion where the admin user might appear as a regular manager. This PR ensures the admin has a unique position, restricts employee creation to admins, prevents employees from having the 'admin' position, and provides new endpoints for clear admin identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-02362669-4b95-444c-abc8-66bcc4b8ecda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02362669-4b95-444c-abc8-66bcc4b8ecda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

